### PR TITLE
Add support for Amazon Linux 2 (RHEL 7 compatible) with Major Release 4

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,21 +54,36 @@ Detected lsbdistcodename is <${::lsbdistcodename}>.")
       $config_dir        = '/etc/monit.d'
       $service_hasstatus = true
 
-      case $::operatingsystemmajrelease {
-        '5': {
-          $monit_version = '4'
-          $config_file   = '/etc/monit.conf'
-        }
-        '6': {
-          $monit_version = '5'
-          $config_file   = '/etc/monit.conf'
-        }
-        '7': {
-          $monit_version = '5'
-          $config_file   = '/etc/monitrc'
+      case $::operatingsystem {
+        'Amazon': {
+          case $::operatingsystemmajrelease {
+            '4': {
+              $monit_version = '5'
+              $config_file   = '/etc/monitrc'
+            }
+            default: {
+              fail("Currently only Amazon linux with Majorrelase 4 supported, Detected operatingsystemmajrelease is <${::operatingsystemmajrelease}>.")
+            }
+          }
         }
         default: {
-          fail("monit supports EL 5, 6 and 7. Detected operatingsystemmajrelease is <${::operatingsystemmajrelease}>.")
+          case $::operatingsystemmajrelease {
+            '5': {
+              $monit_version = '4'
+              $config_file   = '/etc/monit.conf'
+            }
+            '6': {
+              $monit_version = '5'
+              $config_file   = '/etc/monit.conf'
+            }
+            '7': {
+              $monit_version = '5'
+              $config_file   = '/etc/monitrc'
+            }
+            default: {
+              fail("monit supports EL 5, 6 and 7. Detected operatingsystemmajrelease is <${::operatingsystemmajrelease}>.")
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
This is the currently available Amazon Linux 2 version.

Without that fix it will be recognized as RHEL 4.