### PR TITLE
Add amazon linux2 support

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,21 +54,36 @@ Detected lsbdistcodename is <${::lsbdistcodename}>.")
       $config_dir        = '/etc/monit.d'
       $service_hasstatus = true
 
-      case $::operatingsystemmajrelease {
-        '5': {
-          $monit_version = '4'
-          $config_file   = '/etc/monit.conf'
-        }
-        '6': {
-          $monit_version = '5'
-          $config_file   = '/etc/monit.conf'
-        }
-        '7': {
-          $monit_version = '5'
-          $config_file   = '/etc/monitrc'
+      case $::operatingsystem {
+        'Amazon': {
+          case $::operatingsystemmajrelease {
+            '4': {
+              $monit_version = '5'
+              $config_file   = '/etc/monitrc'
+            }
+            default: {
+              fail("Currently only Amazon linux with Majorrelase 4 supported, Detected operatingsystemmajrelease is <${::operatingsystemmajrelease}>.")
+            }
+          }
         }
         default: {
-          fail("monit supports EL 5, 6 and 7. Detected operatingsystemmajrelease is <${::operatingsystemmajrelease}>.")
+          case $::operatingsystemmajrelease {
+            '5': {
+              $monit_version = '4'
+              $config_file   = '/etc/monit.conf'
+            }
+            '6': {
+              $monit_version = '5'
+              $config_file   = '/etc/monit.conf'
+            }
+            '7': {
+              $monit_version = '5'
+              $config_file   = '/etc/monitrc'
+            }
+            default: {
+              fail("monit supports EL 5, 6 and 7. Detected operatingsystemmajrelease is <${::operatingsystemmajrelease}>.")
+            }
+          }
         }
       }
     }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,6 +47,7 @@ describe 'monit' do
             else
               raise 'unsupported operatingsystemmajrelease detected on RedHat osfamily'
             end
+          end
         else
           raise 'unsupported osfamily detected'
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -24,19 +24,29 @@ describe 'monit' do
         when 'RedHat'
           config_dir        = '/etc/monit.d'
           service_hasstatus = true
-          case facts[:operatingsystemmajrelease]
-          when '5'
-            monit_version = '4'
-            config_file   = '/etc/monit.conf'
-          when '6'
-            monit_version = '5'
-            config_file   = '/etc/monit.conf'
-          when '7'
-            monit_version = '5'
-            config_file   = '/etc/monitrc'
+          case facts[:operatingsystem]
+          when 'Amazon'
+            case facts[:operatingsystemmajrelease]
+            when '4'
+              monit_version = '5'
+              config_file   = '/etc/monitrc'
+            else
+              raise 'unsupported operatingsystemmajrelease detected on RedHat osfamily'
+            end
           else
-            raise 'unsupported operatingsystemmajrelease detected on RedHat osfamily'
-          end
+            case facts[:operatingsystemmajrelease]
+            when '5'
+              monit_version = '4'
+              config_file   = '/etc/monit.conf'
+            when '6'
+              monit_version = '5'
+              config_file   = '/etc/monit.conf'
+            when '7'
+              monit_version = '5'
+              config_file   = '/etc/monitrc'
+            else
+              raise 'unsupported operatingsystemmajrelease detected on RedHat osfamily'
+            end
         else
           raise 'unsupported osfamily detected'
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -366,6 +366,7 @@ describe 'monit' do
       let :facts do
         { osfamily:                  'RedHat',
           operatingsystemmajrelease: '4',
+          operatingsystem: 'CentOS',
           monit_version:             '5' }
       end
 


### PR DESCRIPTION
This is the currently available Amazon Linux 2 version.

Without that fix it will be recognized as RHEL 4.