### PR TITLE
Amazon fixed the wrong versioning for Amazon linux 2 

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -59,7 +59,7 @@ Detected lsbdistcodename is <${::lsbdistcodename}>.")
       case $::operatingsystem {
         'Amazon': {
           case $::operatingsystemmajrelease {
-            '4': {
+            '4', '2': {
               $monit_version = '5'
               $config_file   = '/etc/monitrc'
             }


### PR DESCRIPTION
Amazon linux 2 has now Major Release 2 instead of 4. Just after a normal yum update...