### PR TITLE
Fixing logging limitations with syslog.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -90,7 +90,7 @@ class monit (
   validate_bool($service_manage_bool)
   validate_string($service_name)
 
-  if $logfile != 'syslog' {
+  if ($logfile =~ Undef) and !($logfile =~ /^syslog(\s+facility\s+log_(local[0-7]|daemon))?/) {  
     validate_absolute_path($logfile)
   }
 

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -4,7 +4,9 @@ set daemon <%= @check_interval %>
 <%- if @start_delay.to_s != '0' -%>
 with start delay <%= @start_delay %>
 <%- end -%>
+<%- if @logfile -%>
 set logfile <%= @logfile %>
+<%- end -%>
 <%- if scope.function_versioncmp([@monit_version_real, '5']) >= 0 -%>
 set idfile /var/lib/monit/id
 <%- end -%>


### PR DESCRIPTION
According to `monit(1)` man page
```
set logfile     Name of a file to dump error- and status-
                messages to. If syslog is specified as the
                file, Monit will utilize the syslog daemon
                to log messages. This can optionally be
                followed by 'facility <facility>' where
                facility is 'log_local0' - 'log_local7' or
                'log_daemon'. If no facility is specified,
                LOG_USER is used.
```

This PR improves the current behavior that only permits to define a log file, or syslog without any facility. It also permits to set the $syslog value to undef, and to completely disable logging.