### PR TITLE
Added ability to use special characters in httpd_password parameter

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -158,6 +158,21 @@ describe 'monit' do
             it { is_expected.to contain_file('monit_config').with_content(%r{#{content}}) }
           end
 
+          context 'when httpd_password parameter consists special charaters' do
+            let(:params) do
+              {
+                httpd:          true,
+                httpd_port:     2420,
+                httpd_address:  'otherhost',
+                httpd_allow:    '0.0.0.0/0.0.0.0',
+                httpd_user:     'tester',
+                httpd_password: 'Pa$$w0rd',
+              }
+            end
+
+            it { is_expected.to contain_file('monit_config').with_content(%r{^\s+allow tester:"Pa\$\$w0rd"$}) }
+          end
+
           context 'when manage_firewall and http are set to valid bool <true>' do
             let(:pre_condition) { ['include ::firewall'] }
             let(:params) do

--- a/templates/monitrc.erb
+++ b/templates/monitrc.erb
@@ -30,7 +30,11 @@ set httpd port <%= @httpd_port %> and
    use address <%= @httpd_address %>
    allow <%= @httpd_allow %>
    <%- if !@httpd_user.empty? && !@httpd_password.empty? -%>
+   <%-   if @httpd_password =~ %r{^\w+$} -%>
    allow <%= @httpd_user %>:<%= @httpd_password %>
+   <%-   else -%>
+   allow <%= @httpd_user %>:"<%= @httpd_password %>"
+   <%-   end -%>
    <%- end -%>
 <%- end -%>
 <%- if @mmonit_address  -%>


### PR DESCRIPTION
According to Monit documentation https://mmonit.com/monit/documentation/monit.html#TCP-PORT:

You might need to use double quotes around the password if it cointains special chars such as "p@ssw:r#".